### PR TITLE
oop-ext v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,5 @@ Feedstock Maintainers
 * [@kfasolin](https://github.com/kfasolin/)
 * [@lincrosenbach](https://github.com/lincrosenbach/)
 * [@nicoddemus](https://github.com/nicoddemus/)
+* [@gcardozo123](https://github.com/gcardozo123/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "oop-ext" %}
-{% set version = "0.5.0" %}
+{% set version = "0.5.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 61f392e32de21a4274fed7910fc416c6f7a1f27f7b427ec2dae78b5f4aa9593d
+  sha256: 6627cccb2a9f23997e2cab89ef9084b66e983663fee0c28541a2e04bb78dc8fc
 
 build:
   noarch: python


### PR DESCRIPTION
I'm just pointing the `meta.yaml` to `oop-ext v0.5.1` and adding my Github handle to the maintainers on the readme.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
